### PR TITLE
Add new TOC fields from Patch 10.1.0

### DIFF
--- a/grammars/toc-wow.cson
+++ b/grammars/toc-wow.cson
@@ -21,7 +21,7 @@
             'name': 'entity.name.tag.localized.toc'
           }
           {
-            'match': '(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|SavedVariablesPerCharacter|SavedVariables|DefaultState|Author|Version)'
+            'match': '(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|SavedVariablesPerCharacter|SavedVariables|DefaultState|Author|Version|AddonCompartmentFunc|AddonCompartmentFuncOnEnter|AddonCompartmentFuncOnLeave|IconAtlas|IconTexture)'
             'name': 'entity.name.tag.toc'
           }
           {

--- a/grammars/toc-wow.cson
+++ b/grammars/toc-wow.cson
@@ -25,7 +25,7 @@
             'name': 'entity.name.tag.toc'
           }
           {
-            'match': '(?i)(AllowLoad|OnlyBetaAndPTR|SavedVariablesMachine|Secure)'
+            'match': '(?i)(AllowLoad|OnlyBetaAndPTR|SavedVariablesMachine|Secure|GuardedAddOn)'
             'name': 'entity.name.tag.restricted.toc'
           }
           {


### PR DESCRIPTION
This adds a few additional tokens to the grammar for the following fields being made available in 10.1.0:

  - AddonCompartmentFunc
  - AddonCompartmentFuncOnEnter
  - AddonCompartmentFuncOnLeave
  - IconAtlas
  - IconTexture
  - GuardedAddOn (secure only)