### PR TITLE
Update TOC fields for 11.0.0

### DIFF
--- a/grammars/toc-wow.cson
+++ b/grammars/toc-wow.cson
@@ -25,7 +25,7 @@
             'name': 'entity.name.tag.toc'
           }
           {
-            'match': '(?i)(AllowLoad|OnlyBetaAndPTR|SavedVariablesMachine|Secure|GuardedAddOn)'
+            'match': '(?i)(AllowLoad(GameType)?|OnlyBetaAndPTR|SavedVariablesMachine|Secure|LoadFirst|UseSecureEnvironment)'
             'name': 'entity.name.tag.restricted.toc'
           }
           {

--- a/grammars/toc-wow.cson
+++ b/grammars/toc-wow.cson
@@ -21,7 +21,7 @@
             'name': 'entity.name.tag.localized.toc'
           }
           {
-            'match': '(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|SavedVariablesPerCharacter|SavedVariables|DefaultState|Author|Version|AddonCompartmentFunc|AddonCompartmentFuncOnEnter|AddonCompartmentFuncOnLeave|IconAtlas|IconTexture)'
+            'match': '(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|SavedVariablesPerCharacter|SavedVariables|DefaultState|Author|Version|AddonCompartmentFunc(OnEnter|OnLeave)?|IconAtlas|IconTexture)'
             'name': 'entity.name.tag.toc'
           }
           {


### PR DESCRIPTION
This adds the new secure fields that Blizzard added through patches 10.2.6 to 11.0.0:

- AllowLoadGameType
- UseSecureEnvironment
- LoadFirst (renamed from GuardedAddOn).

I've omitted the AllowLoadByGameMode and SuppressLocalTableRef fields. These were added in 10.2.6 and 10.2.7, but both were removed one patch later and aren't present in Mainline. In terms of Classic clients, these fields also won't exist there either come patches 1.15.4 and 4.4.1 in the next few weeks.

I've also fixed highlighting of the "AddonCompartmentFuncOnEnter" and "AddonCompartmentFuncOnLeave" fields; both of these would terminate their match at "AddonCompartmentFunc" and leave the rest of the token unmatched. Now the OnEnter and OnLeave portions should be picked up and highlighted if present.